### PR TITLE
Match device name on Linux

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,7 @@ function stopNote(note){
 }
 
 function isModelCycles(s){
-    return s.name == 'Elektron Model:Cycles'
+    return s.name.indexOf('Elektron Model:Cycles') == 0;
 }
 
 function connectInputs() {


### PR DESCRIPTION
On Linux, the Model:Cycles was not detected.

This happens because the device name on Linux is reported with an additional suffix, i.e. "Elektron Model:Cycles MIDI 1", but the test was looking for an exact match with "Elektron Model:Cycles"

This changes the test to match only the start of the string, ignoring any additional text after the device name.